### PR TITLE
Update XlsxStyled.php

### DIFF
--- a/classes/XlsxStyled.php
+++ b/classes/XlsxStyled.php
@@ -322,7 +322,7 @@ class XlsxStyled extends BaseReader
      *
      * @return Spreadsheet
      */
-    public function load(string $pFilename, int $flags = 0)
+    public function load(string $pFilename, int $flags = 0): Spreadsheet
     {
         File::assertFile($pFilename);
 


### PR DESCRIPTION
Solution for bug causing the following exception:

"Declaration of Vdomah\Excel\Classes\XlsxStyled::load(string $pFilename, int $flags = 0) must be compatible with PhpOffice\PhpSpreadsheet\Reader\BaseReader::load(string $filename, int $flags = 0): PhpOffice\PhpSpreadsheet\Spreadsheet ~\plugins\vdomah\excel\classes\XlsxStyled.php line 325"